### PR TITLE
Eegeyenet changes to lina

### DIFF
--- a/eoglearn/datasets/mne.py
+++ b/eoglearn/datasets/mne.py
@@ -68,9 +68,12 @@ def read_mne_eyetracking_raw(return_events=False, bandpass=True):
     # Add EEG channels to the eye-tracking raw object
     raw_et.add_channels([raw_eeg], force_update_info=True)
 
-    annots = mne.annotations_from_events(eeg_events, raw_et.info["sfreq"],
-                                         event_desc={2: "Flash"},
-                                         orig_time=raw_et.info["meas_date"])
+    annots = mne.annotations_from_events(
+        et_events,
+        raw_et.info["sfreq"],
+        event_desc={2: "Flash"},
+        orig_time=raw_et.info["meas_date"],
+    )
     raw_et.set_annotations(raw_et.annotations + annots)
 
     if return_events:

--- a/eoglearn/io/__init__.py
+++ b/eoglearn/io/__init__.py
@@ -1,1 +1,1 @@
-from .eegeyenet import read_raw_eegeyenet
+from .eegeyenet import read_raw_eegeyenet, get_dot_positions

--- a/eoglearn/io/eegeyenet.py
+++ b/eoglearn/io/eegeyenet.py
@@ -1,9 +1,7 @@
 from importlib import import_module
 
-import numpy as np
-
 import mne
-from mne._fiff.constants import FIFF
+import numpy as np
 
 
 def _check_pymatreader_installed():

--- a/eoglearn/io/eegeyenet.py
+++ b/eoglearn/io/eegeyenet.py
@@ -1,6 +1,9 @@
 from importlib import import_module
 
+import numpy as np
+
 import mne
+from mne._fiff.constants import FIFF
 
 
 def _check_pymatreader_installed():
@@ -78,4 +81,81 @@ def read_raw_eegeyenet(fname):
             ch_dict["loc"][4] = -1
         elif ch_dict["ch_name"].upper().endswith("Y"):
             ch_dict["loc"][4] = 1
+
+    # read the events (dot onsets, blinks etc)
+    eye_chs = [
+        name
+        for name, ch in zip(raw.ch_names, raw.get_channel_types())
+        if ch in ["eyegaze", "pupil"]
+    ]
+    for onset, duration, description in zip(
+        mat_content["event"]["latency"],
+        mat_content["event"]["duration"],
+        mat_content["event"]["type"],
+    ):
+        onset /= mat_content["srate"]
+        duration /= mat_content["srate"]
+        description = description.strip()  # remove trailing whitespace from numbers
+
+        if description in ["55", "56"]:
+            continue  # We dont know what these are. probably some start cue
+        if description.startswith(("L_", "R_")):
+            # remove the L_ or R_ prefix, will put eye info in ch_names key of annot
+            eye = [eye_chs]
+            description = description.lstrip("LR_")
+            if "blink" in description.lower():
+                description = "BAD_" + description
+        else:  # cue or end_cue
+            eye = None
+            if description == "41":
+                description = "end_cue"
+            # cue 1 is the same position as cue 101, so make them the same name
+            elif int(description) >= 100:
+                description = str(int(description) - 100)
+        raw.annotations.append(onset, duration, description, ch_names=eye)
     return raw
+
+
+def get_dot_positions():
+    """Get the x/y pixel coordinates of the dots in the EEGEyeNet dots dataset.
+
+    Returns
+    -------
+    tar_pos_dict : dict
+        dictionary where the keys are the event triggers
+        (``'1'``, ``'2'``, ..., ``'27'``), and the values are arrays of shape ``(2,)``,
+        indicating the x/y positions of the dot shown on the screen.
+    """
+    CUE_TRIGGER = list(map(str, range(1, 28)))
+    TAR_POS = np.array(
+        [
+            [400, 300],
+            [650, 500],
+            [400, 100],
+            [100, 450],
+            [700, 450],
+            [100, 500],
+            [200, 350],
+            [300, 400],
+            [100, 150],
+            [150, 500],
+            [150, 100],
+            [700, 100],
+            [300, 200],
+            [100, 100],
+            [700, 500],
+            [500, 400],
+            [600, 250],
+            [650, 100],
+            [400, 300],
+            [200, 250],
+            [400, 500],
+            [700, 150],
+            [500, 200],
+            [100, 300],
+            [700, 300],
+            [600, 350],
+            [400, 300],
+        ]
+    )
+    return dict(zip(CUE_TRIGGER, TAR_POS))

--- a/eoglearn/io/tests/test_io.py
+++ b/eoglearn/io/tests/test_io.py
@@ -1,4 +1,3 @@
-import numpy as np
 
 from mne._fiff.constants import FIFF
 

--- a/eoglearn/io/tests/test_io.py
+++ b/eoglearn/io/tests/test_io.py
@@ -1,3 +1,7 @@
+import numpy as np
+
+from mne._fiff.constants import FIFF
+
 from eoglearn.datasets import fetch_eegeyenet
 from eoglearn.io import read_raw_eegeyenet
 
@@ -16,3 +20,11 @@ def test_read_raw_eegeyenet():
     assert raw.info["chs"][-2]["loc"][3] == -1  # left eye
     assert raw.info["chs"][-2]["loc"][4] == 1  # ypos
     assert raw.info["chs"][-3]["loc"][4] == -1  # xpos
+    assert raw.info["chs"][-2]["unit"] == FIFF.FIFF_UNIT_PX
+    assert raw.info["chs"][-2]["kind"] == FIFF.FIFFV_EYETRACK_CH
+    assert raw.info["chs"][-2]["coil_type"] == FIFF.FIFFV_COIL_EYETRACK_POS
+    assert raw.info["chs"][-1]["coil_type"] == FIFF.FIFFV_COIL_EYETRACK_PUPIL
+
+    event_triggers = list(map(str, range(1, 28)))
+    for cue in event_triggers:
+        assert cue in raw.annotations.description

--- a/eoglearn/models/model.py
+++ b/eoglearn/models/model.py
@@ -4,8 +4,8 @@
 # License: BSD-3-Clause
 
 import matplotlib.pyplot as plt
-import numpy as np
 import mne
+import numpy as np
 from mne.utils import logger
 from sklearn.preprocessing import StandardScaler
 from tensorflow.keras.layers import LSTM
@@ -34,6 +34,7 @@ class EOGDenoiser:
         The number of timepoints to pass into the LSTM model at once. Defaults to 100.
     noise_picks: list | None
         Channels that contain the noise channels.
+
     Attributes
     ----------
     raw : mne.io.Raw
@@ -73,14 +74,7 @@ class EOGDenoiser:
     on how to create a raw object with both EEG and eyetracking channels.
     """
 
-    def __init__(
-        self,
-        raw,
-        downsample=10,
-        n_units=50,
-        n_times=100,
-        noise_picks=None
-    ):
+    def __init__(self, raw, downsample=10, n_units=50, n_times=100, noise_picks=None):
         self.__x = None
         self.__y = None
         #############################################
@@ -106,6 +100,7 @@ class EOGDenoiser:
 
     @property
     def denoised_neural(self):
+        """Return the MEEG signal without EOG artifact."""
         if self.__denoised_neural is None:
             logger.info(
                 "Denoising neural data, saving to ``denoised_neural_`` attribute."
@@ -292,6 +287,7 @@ class EOGDenoiser:
         self.__denoised_neural = Y_train - predicted_eog
 
     def get_denoised_neural_raw(self):
+        """Return an mne.io.Raw object of the MEEG signal without EOG artifact."""
         raw_y = self._get_y_raw()
         raw_denoised = mne.io.RawArray(self.denoised_neural.T, raw_y.info)
         raw_denoised.set_annotations(raw_y.annotations)

--- a/eoglearn/models/model.py
+++ b/eoglearn/models/model.py
@@ -6,7 +6,6 @@
 import matplotlib.pyplot as plt
 import mne
 import numpy as np
-import mne
 from mne.utils import logger
 from sklearn.preprocessing import StandardScaler
 from tensorflow.keras.layers import LSTM
@@ -19,28 +18,26 @@ from eoglearn.viz import plot_values_topomap
 class EOGDenoiser:
     """Use simultaneous EEG and Eyetracking to Denoise EOG from the EEG data.
 
-        Parameters
-        ----------
+    Parameters
+    ----------
         raw : mne.io.Raw
             An instance of ``mne.io.Raw``, with EEG, eyegaze, and pupil channels.
         downsample : int
             The factor by which to downsample the EEG and eyetracking data. EEG channels
-            will be low-pass filtered before downsampling using ``mne.io.filter.resample``.
-            Eyetracking channels will be decimated without any filtering. resampling and
-            decimating will be done on copies of the data, so the original input data will
-            be preserved.
+            will be low-pass filtered before downsampling using
+            ``mne.io.filter.resample``. Eyetracking channels will be decimated without
+            any filtering. resampling and decimating will be done on copies of the data,
+            so the original input data will be preserved.
         n_units : int
             The number of units to pass into the initial LSTM layer. Defaults to 50.
         n_times : int
-            The number of timepoints to pass into the LSTM model at once. Defaults to 100.
+            The number of timepoints to pass into the LSTM model at once. Defaults to
+            100.
         noise_picks: list | None
             Channels that contain the noise channels.
-    <<<<<<< HEAD
 
-    =======
-    >>>>>>> lina/main
-        Attributes
-        ----------
+    Attributes
+    ----------
         raw : mne.io.Raw
             The original input ``mne.io.Raw`` instance.
         downsample : int
@@ -72,8 +69,8 @@ class EOGDenoiser:
             i.e. ``(n_samples, n_meeg_channels)`` of the input :class:`~mne.io.Raw`
             object.
 
-        Notes
-        -----
+    Notes
+    -----
         See the MNE-Python tutorial on aligning EEG and eyetracking data for information
         on how to create a raw object with both EEG and eyetracking channels.
     """

--- a/eoglearn/viz/topo.py
+++ b/eoglearn/viz/topo.py
@@ -93,5 +93,5 @@ def plot_values_topomap(
 
     if colorbar:
         fig.colorbar(im[0], ax=axes, shrink=0.6, label="Percentage of EOG in signal")
-    plt_show(show)
+    plt_show(show, fig)
     return fig

--- a/examples/plot_eegeyenet.py
+++ b/examples/plot_eegeyenet.py
@@ -70,6 +70,7 @@ fig.show()
 # %%
 # Plot a gaze heatmap
 # -------------------
+#
 # Let's plot a heatmap of the subject's gaze over the course of the task,
 # to see if they were looking at the dots.
 

--- a/examples/plot_eegeyenet.py
+++ b/examples/plot_eegeyenet.py
@@ -11,15 +11,17 @@ which presents a subject with a series of dots at fixed locations on the screen.
 # %%
 # Import the necessary packages
 # ----------------------------
-from eoglearn.datasets import fetch_eegeyenet
-from eoglearn.io import read_raw_eegeyenet
-from eoglearn.models import EOGDenoiser
+import matplotlib.pyplot as plt
+
+import eoglearn
 import mne
 
+from mne.viz.eyetracking import plot_gaze
 
-fpath = fetch_eegeyenet()
+
+fpath = eoglearn.datasets.fetch_eegeyenet()
 fname = fpath / "EP10_DOTS1_EEG.mat"
-raw = read_raw_eegeyenet(fname)
+raw = eoglearn.io.read_raw_eegeyenet(fname)
 raw
 
 # %%
@@ -30,7 +32,7 @@ raw.plot()
 # %%
 # Create and fit model
 # --------------------
-eog_denoiser = EOGDenoiser(raw, downsample=5)
+eog_denoiser = eoglearn.models.EOGDenoiser(raw, downsample=5)
 eog_denoiser.fit_model(epochs=10)  # limit to 10 epochs for speed
 
 # %%
@@ -38,3 +40,49 @@ eog_denoiser.fit_model(epochs=10)  # limit to 10 epochs for speed
 # ----------------------------------
 montage = mne.channels.make_standard_montage("GSN-HydroCel-129")
 eog_denoiser.plot_eog_topo(montage=montage)
+
+# %%
+# Understanding the task structure
+# --------------------------------
+#
+# In the dots task, a subject is presented with a series of dots at fixed
+# locations on the screen. In the data, the dot onsets are marked with
+# an integer event trigger.
+
+# %%
+target_positions = eoglearn.io.eegeyenet.get_dot_positions()
+
+fig, ax = plt.subplots()
+for trigger, position in target_positions.items():
+    ax.scatter(*position)
+    xy = (
+        position - 10
+        if trigger == "1"
+        else position + 10
+        if trigger == "27"
+        else position
+    )
+    ax.text(*xy, trigger)
+ax.invert_yaxis()
+ax.set_title("Dot positions")
+fig.show()
+
+# %%
+# Plot a gaze heatmap
+# -------------------
+# Let's plot a heatmap of the subject's gaze over the course of the task,
+# to see if they were looking at the dots.
+
+# %%
+mne.preprocessing.eyetracking.interpolate_blinks(raw, interpolate_gaze=True)
+# Events from annotations
+events, _ = mne.events_from_annotations(raw, regexp="^[0-9]*$")
+
+# Epoch data from events 1-second
+epochs = mne.Epochs(raw, events, tmin=0, tmax=1, baseline=None)
+
+# Get data and pick our eyetrack channels
+data = epochs.get_data(picks=["L-GAZE-X", "L-GAZE-Y"])
+
+# Plot heatmap
+plot_gaze(epochs, width=800, height=600)

--- a/examples/plot_model.py
+++ b/examples/plot_model.py
@@ -11,6 +11,7 @@ channels..
 # %%
 # Import the necessary packages
 import mne
+import matplotlib.pyplot as plt
 from eoglearn.datasets import read_mne_eyetracking_raw
 from eoglearn.models import EOGDenoiser
 
@@ -38,6 +39,8 @@ eog_denoiser
 # %%
 # Fit the model
 # We will only use 10 epochs to speed up the example
+
+# %%
 eog_denoiser.fit_model(epochs=10)
 history = eog_denoiser.model.history
 
@@ -45,6 +48,7 @@ history = eog_denoiser.model.history
 # display the training history
 print(history.history["loss"])
 print(history.history["val_loss"])
+eog_denoiser.plot_loss()
 
 # %%
 # Plot a topomap of the predicted EOG artifact.
@@ -52,6 +56,8 @@ print(history.history["val_loss"])
 # The plot below displays the predicted amount of EOG artifact for each EEG sensor.
 # The output is as we would expect, with frontal sensors containing the most EOG
 # artifact.
+
+# %%
 montage = mne.channels.make_standard_montage("GSN-HydroCel-129")
 eog_denoiser.plot_eog_topo(montage=montage)
 
@@ -59,3 +65,33 @@ eog_denoiser.plot_eog_topo(montage=montage)
 # .. todo::
 #    Add a plot of the predicted EOG artifact for each EEG sensor over time.
 #    Add plots of the denoised EEG data.
+
+# %%
+# Compare ERP between the original and "EOG-denoised" signals
+# -----------------------------------------------------------
+#
+# Let's create an averaged evoked response to the flash stimuli for both the original
+# data and the "EOG-denoised" data. We'll focus on the frontal EEG channels, since it is
+# these will contain the most EOG in the original signal.
+
+# %%
+pred_raw = eog_denoiser.get_denoised_neural_raw()
+events, event_id = mne.events_from_annotations(pred_raw, regexp="Flash")
+pred_epochs = mne.Epochs(
+    pred_raw, events=events, event_id=event_id, tmin=-0.3, tmax=3, preload=True
+)
+
+events, event_id = mne.events_from_annotations(eog_denoiser.raw, regexp="Flash")
+original_epochs = mne.Epochs(
+    eog_denoiser.raw, events=events, event_id=event_id, tmin=-0.3, tmax=3, preload=True
+)
+
+frontal = ["E19", "E11", "E4", "E12", "E5"]
+pred_avg_frontal = pred_epochs.average().get_data(picks=frontal).mean(0)
+original_avg_frontal = original_epochs.average().get_data(picks=frontal).mean(0)
+
+ax = plt.subplot()
+ax.plot(pred_epochs.times, pred_avg_frontal, label="predicted")
+ax.plot(original_epochs.times, original_avg_frontal, label="original")
+ax.set_xlim(-0.3, 1)
+ax.legend()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ doc = [
     'sphinx-issues',
 ]
 
-extras = ['pymatreader', 'pandas']
+extras = ['pymatreader', 'pandas', 'defusedxml']
 
 test = [
     'black',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ all = [
     'eoglearn[gpu]',
     'eoglearn[doc]',
     'eoglearn[test]',
+    'eoglearn[extras]',
 ]
 full = [
     'eoglearn[all]',


### PR DESCRIPTION
Hey @christian-oreilly I updated the `read_raw_eegeyenet` reader so that it reads in the event triggers and ocular-events as `mne.annotations` (so we can actually epoch to the onsets of the target dots).  I am opening this PR so that the changes will appear on the lina fork and since you'd like to work off of the lina fork. Actually I'd rather just transfer the repository ownership to lina so that it can be the upstream branch, but you'd have to delete the current lina fork first (Or I need to change the base repository name before transferring it):

